### PR TITLE
Always Be Releasing

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,13 @@
+name: Autotag and Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./bin/tag-release.sh
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+## Releases
+New releases are tagged and released automatically on merge to main with [autotag](https://github.com/pantheon-systems/autotag) and the `gh` CLI tool. See [Autotag's README](https://github.com/pantheon-systems/autotag#scheme-autotag-default) for details of how to annotate commit messages to denote major, minor, or patch version bumps.
+
+### Releasing to GitHub Action Marketplace
+The release automation creates the tag and release, but `gh` cannot actually publish to the marketplace. To update the version available in the GitHub Marketplace, click the edit buttion on the latest release on the ["Release" page](https://github.com/pantheon-systems/validate-readme-spacing/releases) then on the edit page, check "Publish this Action to the GitHub Marketplace" and then click _Update Release_.

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -14,3 +14,18 @@ fi
 NEW_RELEASE=$(./bin/autotag)
 git push --tags
 gh release create "v${NEW_RELEASE}" -t "v${NEW_RELEASE}" --generate-notes
+
+# Extract the major version number
+MAJOR_VERSION=$(echo "${NEW_RELEASE}" | cut -d'.' -f1)
+
+echo "Major version: ${MAJOR_VERSION}"
+
+MAJOR_VERSION_BRANCH="v${MAJOR_VERSION}"
+if git show-ref --verify --quiet "refs/heads/${MAJOR_VERSION_BRANCH}"; then
+  git checkout -b "${MAJOR_VERSION_BRANCH}"
+else
+  git checkout "${MAJOR_VERSION_BRANCH}"
+  git merge --ff-only main
+fi
+
+git push origin "${MAJOR_VERSION_BRANCH}"

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -6,7 +6,7 @@ curl -sL https://git.io/autotag-install | sh --
 # fetch all tags and history:
 git fetch --tags --unshallow --prune
 
-if [ $(git rev-parse --abbrev-ref HEAD) != "main" ]; then
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
   # ensure a local 'main' branch exists at 'refs/heads/main'
   git branch --track main origin/main
 fi

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+curl -sL https://git.io/autotag-install | sh --
+
+# fetch all tags and history:
+git fetch --tags --unshallow --prune
+
+if [ $(git rev-parse --abbrev-ref HEAD) != "main" ]; then
+  # ensure a local 'main' branch exists at 'refs/heads/main'
+  git branch --track main origin/main
+fi
+
+NEW_RELEASE=$(./bin/autotag)
+git push --tags
+gh release create "v${NEW_RELEASE}" -t "v${NEW_RELEASE}" --generate-notes

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -22,10 +22,10 @@ echo "Major version: ${MAJOR_VERSION}"
 
 MAJOR_VERSION_BRANCH="v${MAJOR_VERSION}"
 if git show-ref --verify --quiet "refs/heads/${MAJOR_VERSION_BRANCH}"; then
-  git checkout -b "${MAJOR_VERSION_BRANCH}"
-else
   git checkout "${MAJOR_VERSION_BRANCH}"
   git merge --ff-only main
+else
+  git checkout -b "${MAJOR_VERSION_BRANCH}"
 fi
 
 git push origin "${MAJOR_VERSION_BRANCH}"


### PR DESCRIPTION
On merge to main, a tag is created and a release is created from this tag. Adding [major] [minor] or [patch] to commit message will determine how autotag increments.

Note, gh cli cannot release actions to the marketplace, but you can edit the release and then simply hit publish and it will ship. 

A starting tag needs to exist for autotag to have a starting place and we may as well make that our first release (we should decide if we want that to be 0.0.1 or 1.0.0).

~I'm not 100% sure where to document some of this, as README.MD ends up in the marketplace front page. CONTRIBUTING.md?~

c/f https://github.com/pantheon-systems/autotag