### PR TITLE
Fix the active branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,3 +42,4 @@ runs:
         DEFAULT_BRANCH: ${{ inputs.default-branch }}
         GH_TOKEN: ${{ github.token }}
         THIS_REPO: ${{ github.repository }}
+        ACTIVE_BRANCH: ${{ github.ref }}

--- a/bin/dependency-check-pr.sh
+++ b/bin/dependency-check-pr.sh
@@ -100,11 +100,12 @@ main() {
     echo
   done
   if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "Dry run requested...checking the diff...🤔"
     BRANCH="${DEFAULT_BRANCH}"
     if [[ ${ACTIVE_BRANCH} != ${BRANCH} ]]; then
+      echo "Default branch is ${BRANCH}, but active branch is ${ACTIVE_BRANCH}. We'll check out ${ACTIVE_BRANCH} instead."
       BRANCH="${ACTIVE_BRANCH}"
     fi
-    echo "Dry run requested...checking the diff...🤔"
     # If we're doing a dry-run, let's output a diff so we can see that it did something.
     if git rev-parse --verify HEAD >/dev/null 2>&1; then
       diff_output=$(git diff --color=always -U0 "${BRANCH}"...HEAD)

--- a/bin/dependency-check-pr.sh
+++ b/bin/dependency-check-pr.sh
@@ -83,11 +83,11 @@ main() {
 
     if [[ ${DRY_RUN} == "false" ]]; then
         git push origin "${BRANCH}"
-    
+
         PR_BODY="Bumps [${NAME}](https://github.com/${REPO}/releases/tag/${LATEST_TAG}) from ${CURRENT_TAG} to ${LATEST_TAG}."
 
         create_label_if_not_exists "dependencies" "#207de5" "Dependencies"
-        create_label_if_not_exists "automation" "#207de5" "Automation"        
+        create_label_if_not_exists "automation" "#207de5" "Automation"
         NEW_PR=$(gh pr create -l dependencies,automation -t "${PR_TITLE}" -b "${PR_BODY}" -R "${THIS_REPO}")
 
         git checkout -
@@ -99,13 +99,16 @@ main() {
     fi
     echo
   done
-  if [[ ${DRY_RUN} == "true" ]]; then
+  if [[ "${DRY_RUN}" == "true" ]]; then
     echo "Dry run requested...checking the diff...🤔"
-    diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}"...HEAD)
-
-    # If we're doing a dry-run, let's output something so we can see that it did something.
-    echo "$diff_output"
+    # If we're doing a dry-run, let's output a diff so we can see that it did something.
+    if git rev-parse --verify HEAD >/dev/null 2>&1; then
+      diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}"...HEAD)
+      echo "$diff_output"
+    else
+      echo "No commits found for diff."
     fi
+  fi
   echo "✨ Done"
 }
 

--- a/bin/dependency-check-pr.sh
+++ b/bin/dependency-check-pr.sh
@@ -107,7 +107,7 @@ main() {
     echo "Dry run requested...checking the diff...🤔"
     # If we're doing a dry-run, let's output a diff so we can see that it did something.
     if git rev-parse --verify HEAD >/dev/null 2>&1; then
-      diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}"...HEAD)
+      diff_output=$(git diff --color=always -U0 "${BRANCH}"...HEAD)
       echo "$diff_output"
     else
       echo "No commits found for diff."

--- a/bin/dependency-check-pr.sh
+++ b/bin/dependency-check-pr.sh
@@ -107,11 +107,10 @@ main() {
     echo "Dry run requested...checking the diff...🤔"
     # If we're doing a dry-run, let's output a diff so we can see that it did something.
     if git rev-parse --verify HEAD >/dev/null 2>&1; then
-      diff_output=$(git diff --color=always -U0 "${BRANCH}" HEAD)
+      diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}"...HEAD)
       echo "$diff_output"
     else
-      diff_output=$(git diff --color=always -U0 "${BRANCH}")
-      echo "$diff_output"
+      echo "No commits found for diff."
     fi
   fi
   echo "✨ Done"

--- a/bin/dependency-check-pr.sh
+++ b/bin/dependency-check-pr.sh
@@ -102,7 +102,7 @@ main() {
   if [[ "${DRY_RUN}" == "true" ]]; then
     echo "Dry run requested...checking the diff...🤔"
     BRANCH="${DEFAULT_BRANCH}"
-    if [[ ${ACTIVE_BRANCH} != ${BRANCH} ]]; then
+    if [[ "${ACTIVE_BRANCH}" != "${BRANCH}" ]]; then
       echo "Default branch is ${BRANCH}, but active branch is ${ACTIVE_BRANCH}. We'll check out ${ACTIVE_BRANCH} instead."
       BRANCH="${ACTIVE_BRANCH}"
     fi

--- a/bin/dependency-check-pr.sh
+++ b/bin/dependency-check-pr.sh
@@ -103,10 +103,11 @@ main() {
     echo "Dry run requested...checking the diff...🤔"
     # If we're doing a dry-run, let's output a diff so we can see that it did something.
     if git rev-parse --verify HEAD >/dev/null 2>&1; then
-      diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}"...HEAD)
+      diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}" HEAD)
       echo "$diff_output"
     else
-      echo "No commits found for diff."
+      diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}")
+      echo "$diff_output"
     fi
   fi
   echo "✨ Done"

--- a/bin/dependency-check-pr.sh
+++ b/bin/dependency-check-pr.sh
@@ -100,13 +100,17 @@ main() {
     echo
   done
   if [[ "${DRY_RUN}" == "true" ]]; then
+    BRANCH="${DEFAULT_BRANCH}"
+    if [[ ${ACTIVE_BRANCH} != ${BRANCH} ]]; then
+      BRANCH="${ACTIVE_BRANCH}"
+    fi
     echo "Dry run requested...checking the diff...🤔"
     # If we're doing a dry-run, let's output a diff so we can see that it did something.
     if git rev-parse --verify HEAD >/dev/null 2>&1; then
-      diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}" HEAD)
+      diff_output=$(git diff --color=always -U0 "${BRANCH}" HEAD)
       echo "$diff_output"
     else
-      diff_output=$(git diff --color=always -U0 "${DEFAULT_BRANCH}")
+      diff_output=$(git diff --color=always -U0 "${BRANCH}")
       echo "$diff_output"
     fi
   fi


### PR DESCRIPTION
If tests (and therefore the action) were being run on a branch that was not the default branch, the diff would fail because there were no changes. This PR updates the dry-run workflow and the action to pass the current `${{ github.ref }}` as the ACTIVE_BRANCH and then runs the diff against _that_ if we're not on the DEFAULT_BRANCH.