### PR TITLE
[JFDI] Restore write permission & handle edits to PR names

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
+
 jobs:
   tag-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-self.yml
+++ b/.github/workflows/update-self.yml
@@ -2,6 +2,11 @@ name: Package Updater
 on: 
   schedule:
     - cron: '0 * * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/bin/dependency-check-pr.sh
+++ b/bin/dependency-check-pr.sh
@@ -49,13 +49,14 @@ main() {
     local NUMBER_TO_CLOSE_LATER=""
     for PR in $(jq -c '.[]' <<<"${LIST_OF_PRS}"); do
       echo "${PR}"
-      if [[ "$(jq -cr .title<<<"${PR}")" == "${PR_TITLE}" ]]; then
+      if [[ "$(jq -cr .title<<<"${PR}")" == *"${PR_TITLE}" ]]; then
         # This captures open PRs, or PRs closed without merging
+        # Prepended wildcards allows PR to be manually edited with a JIRA ticket
         echo "PR Already Created"
         continue 2
       fi
 
-      if [[ "$(jq -cr .title<<<"${PR}")" == "${PR_TITLE_BASE}"* && "$(jq -cr .closed<<<"${PR}")" == "false" ]]; then
+      if [[ "$(jq -cr .title<<<"${PR}")" == *"${PR_TITLE_BASE}"* && "$(jq -cr .closed<<<"${PR}")" == "false" ]]; then
         echo "PR for a Previous version exists"
         NUMBER_TO_CLOSE_LATER="$(jq -cr .number<<<"${PR}")"
         echo "${NUMBER_TO_CLOSE_LATER}"


### PR DESCRIPTION
On a project I prepended bot-created PRs with JIRA tickets, so the "check for matching PRs" step missed and more PRs were created.

Automation will now handle with a an open PR is prepended with something after the fact

Adds write access back where needed.