### PR TITLE
ci: Update and pin GitHub Actions to latest versions (DELENG-239)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,7 +11,7 @@ jobs:
   tag-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pantheon-systems/action-autotag@v0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: pantheon-systems/action-autotag@1b99f88428c5cbd6f73005e4d684c6a22350f5ab # v1.0.3
         with:
           gh-token: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Shellcheck
         run: shellcheck bin/*.sh
   test:
     runs-on: ubuntu-latest
     name: Test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./
         with:
           dependencies-yml: ./fixtures/dependencies.yml

--- a/.github/workflows/update-self.yml
+++ b/.github/workflows/update-self.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Update Dependencies
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./
         with:
           dependencies-yml: ./dependencies.yml


### PR DESCRIPTION
Automated update of GitHub Actions to their latest release versions and pinned to commit SHAs.

This ensures you're using the most recent stable versions while also preventing supply chain attacks.

## Related Ticket
https://getpantheon.atlassian.net/browse/DELENG-239

## Need Help?
If you have questions or need help, ask in Slack [#ask-delivery-engineering](https://pantheon.enterprise.slack.com/archives/C09SPT0A65B)